### PR TITLE
Add SendGrid adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     ],
     "require": {
         "php": ">=5.6",
-        "mandrill/mandrill": "1.0.*"
+        "mandrill/mandrill": "1.0.*",
+        "sendgrid/sendgrid": "^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/lib/NotificationController.php
+++ b/lib/NotificationController.php
@@ -127,6 +127,7 @@ final class NotificationController {
 	public function plugin_page_init() {
 		register_setting( 'rplus-notifications-email', 'rplus_notifications_sender_email' );
 		register_setting( 'rplus-notifications-email', 'rplus_notifications_sender_name' );
+		register_setting( 'rplus-notifications-email', 'rplus_notifications_adapters_sendgrid_apikey' );
 		register_setting( 'rplus-notifications-email', 'rplus_notifications_adapters_mandrill_apikey' );
 		register_setting( 'rplus-notifications-email', 'rplus_notifications_adapters_mandrill_override_wp_mail' );
 		register_setting( 'rplus-notifications-email', 'rplus_notifications_adapters_mandrill_override_use_queue' );
@@ -174,8 +175,27 @@ final class NotificationController {
 		);
 
 		add_settings_field(
+			'rplus_notifications_adapters_sendgrid_apikey',
+			__( 'SendGrid API Key', 'rplusnotifications' ),
+			function() {
+				if ( defined( 'RPLUS_NOTIFICATIONS_ADAPTER_SENDGRID_API_KEY' ) ) {
+					?><input type="text" class="regular-text" readonly value="***************<?php echo substr( RPLUS_NOTIFICATIONS_ADAPTER_SENDGRID_API_KEY, -4 )?>">
+					<p class="description"><?php esc_html_e( 'SendGrid API Key ist via wp-config.php definiert', 'rplusnotifications' ); ?></p>
+					<input type="hidden" id="rplus_notifications_adapters_mandrill_apikey"
+							 name="rplus_notifications_adapters_sendgrid_apikey" value=""/><?php
+				} else {
+					?><input type="text" class="regular-text" id="rplus_notifications_adapters_sendgrid_apikey"
+							 name="rplus_notifications_adapters_sendgrid_apikey"
+							 value="<?php echo esc_attr( get_option( 'rplus_notifications_adapters_sendgrid_apikey' ) ); ?>" /><?php
+				}
+			},
+			'rplus-notifications',
+			'rplus_notifications_adapters'
+		);
+
+		add_settings_field(
 			'rplus_notifications_adapters_mandrill_apikey',
-			__( 'Madrill API Key', 'rplusnotifications' ),
+			__( 'Mandrill API Key', 'rplusnotifications' ),
 			function() {
 				if ( defined( 'RPLUS_NOTIFICATIONS_ADAPTER_MANDRILL_API_KEY' ) ) {
 					?><input type="text" class="regular-text" readonly value="***************<?php echo substr( RPLUS_NOTIFICATIONS_ADAPTER_MANDRILL_API_KEY, -4 )?>">
@@ -338,4 +358,3 @@ final class NotificationController {
 		return $notification;
 	}
 }
-

--- a/lib/NotificationModel.php
+++ b/lib/NotificationModel.php
@@ -52,9 +52,21 @@ class NotificationModel {
 	private $bcc = [];
 
 	/**
+	 * Reply-To for this notification.
+	 *
+	 * @var array
+	 */
+	private $reply_to = [];
+
+	/**
 	 * @var string the message body
 	 */
 	private $body = null;
+
+	/**
+	 * @var string the content type
+	 */
+	private $content_type = 'text/html';
 
 	/**
 	 * @var array file attachments
@@ -432,6 +444,7 @@ class NotificationModel {
 
 		$this->setAdapter( get_post_meta( $this->id, 'rplus_adapter', true ) );
 		$this->setBody( get_post_meta( $this->id, 'rplus_mail_body', true ) );
+		$this->setContentType( get_post_meta( $this->id, 'rplus_mail_content_type', true ) );
 		$this->setState( get_post_meta( $this->id, 'rplus_state', true ) );
 		$this->setSubject( $this->post->post_title );
 		$this->setSchedule( get_post_meta( $this->id, 'rplus_send_on', true ) );
@@ -566,6 +579,20 @@ class NotificationModel {
 	}
 
 	/**
+	 * Add a notification Reply-to.
+	 *
+	 * @param string      $email the email address
+	 * @param string|null $name  optional name
+	 *
+	 * @return NotificationModel allows chaining
+	 */
+	public function addReplyTo( $email, $name = null ) {
+		$this->reply_to[] = [ $email, $name ];
+
+		return $this;
+	}
+
+	/**
 	 * Set the notification BCC recipient, just one email address possible here
 	 *
 	 * @deprecated Use addBccRecipient().
@@ -604,6 +631,18 @@ class NotificationModel {
 	 */
 	public function setBody( $body ) {
 		$this->body = $body;
+
+		return $this;
+	}
+
+	/**
+	 * Set a notification message content type.
+	 *
+	 * @param string $content_type The message content type.
+	 * @return NotificationModel
+	 */
+	public function setContentType( $content_type ) {
+		$this->content_type = $content_type;
 
 		return $this;
 	}
@@ -710,6 +749,15 @@ class NotificationModel {
 	}
 
 	/**
+	 * Get the notification content type.
+	 *
+	 * @return string
+	 */
+	public function getContentType() {
+		return $this->content_type;
+	}
+
+	/**
 	 * Get the notification send date
 	 *
 	 * @return string
@@ -743,6 +791,14 @@ class NotificationModel {
 	 */
 	public function getBccRecipient() {
 		return $this->bcc;
+	}
+	/**
+	 * Get the notification reply-to.
+	 *
+	 * @return array
+	 */
+	public function getReplyTo() {
+		return $this->reply_to;
 	}
 
 	/**
@@ -855,12 +911,14 @@ class NotificationModel {
 
 		// set all other properties
 		update_post_meta( $this->id, 'rplus_mail_body', $this->getBody() );
+		update_post_meta( $this->id, 'rplus_mail_content_type', $this->content_type );
 		update_post_meta( $this->id, 'rplus_adapter', $this->adapter );
 		update_post_meta( $this->id, 'rplus_sender_email', $this->sender_email );
 		update_post_meta( $this->id, 'rplus_sender_name', $this->sender_name );
 		update_post_meta( $this->id, 'rplus_recipient', $this->recipient );
 		update_post_meta( $this->id, 'rplus_recipient_cc', $this->cc );
 		update_post_meta( $this->id, 'rplus_recipient_bcc', $this->bcc );
+		update_post_meta( $this->id, 'rplus_reply_to', $this->reply_to );
 		update_post_meta( $this->id, 'rplus_attachment', $this->attachment );
 		update_post_meta( $this->id, 'rplus_send_on', $this->send_on );
 		update_post_meta( $this->id, 'rplus_state', $this->state );
@@ -906,4 +964,3 @@ class NotificationModel {
 		}
 	}
 }
-

--- a/lib/function.override.wp_mail.php
+++ b/lib/function.override.wp_mail.php
@@ -134,7 +134,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = [] ) {
 
 		$notification = req_notifications()->addNotification();
 		$notification
-			->setAdapter( apply_filters( 'rplus_notifications.wp_mail_default_adapter', 'SendGrid' ) )
+			->setAdapter( apply_filters( 'rplus_notifications.wp_mail_default_adapter', 'Mandrill' ) )
 			->setSubject( $subject )
 			->setBody( $message )
 			->setContentType( $content_type );

--- a/lib/function.override.wp_mail.php
+++ b/lib/function.override.wp_mail.php
@@ -47,8 +47,12 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = [] ) {
 			$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
 		}
 
-		$cc = $bcc = array();
-		$from_email = $from_name = null;
+		// Headers
+		$cc         = array();
+		$bcc        = array();
+		$reply_to   = array();
+		$from_email = null;
+		$from_name  = null;
 
 		if ( ! empty( $headers ) ) {
 			if ( ! is_array( $headers ) ) {
@@ -99,23 +103,45 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = [] ) {
 								$from_email = trim( $content );
 							}
 							break;
+						case 'content-type':
+							if ( strpos( $content, ';' ) !== false ) {
+								list( $type ) = explode( ';', $content );
+								$content_type = trim( $type );
+							} elseif ( '' !== trim( $content ) ) {
+								$content_type = trim( $content );
+							}
+							break;
 						case 'cc':
 							$cc = array_merge( (array) $cc, explode( ',', $content ) );
 							break;
 						case 'bcc':
 							$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
 							break;
+						case 'reply-to':
+							$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
+							break;
 					}
 				}
 			}
 		}
 
+		// If we don't have a content-type from the input headers
+		if ( ! isset( $content_type ) ) {
+			$content_type = 'text/plain';
+		}
+
+		$content_type = apply_filters( 'wp_mail_content_type', $content_type );
 
 		$notification = req_notifications()->addNotification();
 		$notification
-			->setAdapter( 'Mandrill' )
+			->setAdapter( apply_filters( 'rplus_notifications.wp_mail_default_adapter', 'SendGrid' ) )
 			->setSubject( $subject )
-			->setBody( $message );
+			->setBody( $message )
+			->setContentType( $content_type );
+
+		foreach ( $reply_to as $recipient ) {
+			$notification->addReplyTo( $recipient );
+		}
 
 		foreach ( $to as $recipient ) {
 			$notification->addRecipient( $recipient );

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,6 +7,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 delete_option( 'rplus_notifications_sender_email' );
 delete_option( 'rplus_notifications_sender_name' );
 delete_option( 'rplus_notifications_adapters_mandrill_apikey' );
+delete_option( 'rplus_notifications_adapters_sendgrid_apikey' );
 delete_option( 'rplus_notifications_adapters_mandrill_override_wp_mail' );
 
 wp_clear_scheduled_hook( 'rplus_notification_cron_hook' );


### PR DESCRIPTION
* Adds PHP API Library for Twilio SendGrid Web API v3 https://github.com/sendgrid/sendgrid-php
* Adds setting for SendGrid API key
* Extends wp_mail() override to support custom content-type and reply-to headers
* Adds filter rplus_notifications.wp_mail_default_adapter to override default adapter for wp_mail()