### PR TITLE
Switch to mailchimp/transactional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "mandrill/mandrill": "1.0.*",
+        "mailchimp/transactional": "^1.0",
         "sendgrid/sendgrid": "^7.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.2",
         "mailchimp/transactional": "^1.0",
         "sendgrid/sendgrid": "^7.4"
     },

--- a/lib/NotificationAdapterMandrill.php
+++ b/lib/NotificationAdapterMandrill.php
@@ -144,7 +144,7 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 
 		/** @var \MailchimpTransactional\Api\MessagesApi $messages_api */
 		$messages_api = $this->mandrill->messages;
-		$response     = $messages_api->send( [ 'messages' => $message ] );
+		$response     = $messages_api->send( [ 'message' => $message ] );
 
 		if ( $response instanceof \GuzzleHttp\Exception\RequestException ) {
 			$model->setState( NotificationState::ERROR );

--- a/lib/NotificationAdapterMandrill.php
+++ b/lib/NotificationAdapterMandrill.php
@@ -58,7 +58,9 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 			$this->mandrill->setApiKey( $api_key );
 
 			// check if we got a valid API Key
-			$this->mandrill->users->ping();
+			/** @var \MailchimpTransactional\Api\UsersApi */
+			$users_api = $this->mandrill->users;
+			$users_api->ping();
 
 			// when ping works, the API Key is valid.
 			$this->valid_api_key = true;
@@ -140,14 +142,16 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 			}
 		}
 
-		$response = $this->mandrill->messages->send( [ 'messages' => $message ] );
+		/** @var \MailchimpTransactional\Api\MessagesApi $messages_api */
+		$messages_api = $this->mandrill->messages;
+		$response     = $messages_api->send( [ 'messages' => $message ] );
 
 		if ( $response instanceof \GuzzleHttp\Exception\RequestException ) {
 			$model->setState( NotificationState::ERROR );
 			$this->error = \get_class( $response ) . ' - ' . json_decode( $response->getResponse()->getBody()->getContents() )->message;
 			return false;
 		} else {
-			// update post with mandrill message id.
+			// update post with mandrill message response.
 			update_post_meta( $model->getId(), 'rplus_mandrill_response', $response );
 			$model->setState( NotificationState::COMPLETE );
 			return true;

--- a/lib/NotificationAdapterMandrill.php
+++ b/lib/NotificationAdapterMandrill.php
@@ -2,10 +2,6 @@
 
 namespace Rplus\Notifications;
 
-use Exception;
-use MailchimpTransactional\ApiClient;
-use MailchimpTransactional\ApiException;
-
 /**
  * Class NotificationAdapterMandrill
  *
@@ -18,7 +14,7 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 	/**
 	 * The Mandrill object
 	 *
-	 * @var \Mandrill|null
+	 * @var \MailchimpTransactional\ApiClient|null
 	 */
 	private $mandrill = null;
 
@@ -67,7 +63,7 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 			// when ping works, the API Key is valid.
 			$this->valid_api_key = true;
 
-		} catch ( Exception $e ) {
+		} catch ( \Exception $e ) {
 			$this->valid_api_key = false;
 			$this->error         = get_class( $e ) . ' - ' . $e->getMessage();
 		}

--- a/lib/NotificationAdapterMandrill.php
+++ b/lib/NotificationAdapterMandrill.php
@@ -3,8 +3,8 @@
 namespace Rplus\Notifications;
 
 use Exception;
-use Mandrill;
-use Mandrill_Error;
+use MailchimpTransactional\ApiClient;
+use MailchimpTransactional\ApiException;
 
 /**
  * Class NotificationAdapterMandrill
@@ -58,7 +58,8 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 				$api_key = get_option( 'rplus_notifications_adapters_mandrill_apikey' );
 			}
 
-			$this->mandrill = new Mandrill( $api_key );
+			$this->mandrill = new \MailchimpTransactional\ApiClient();
+			$this->mandrill->setApiKey( $api_key );
 
 			// check if we got a valid API Key
 			$this->mandrill->users->ping();
@@ -145,17 +146,17 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 
 		try {
 
-			$response = $this->mandrill->messages->send( $message );
+			$response = $this->mandrill->messages->send( [ 'messages' => $message ] );
 
 			// update post with mandrill message id
 			update_post_meta( $model->getId(), 'rplus_mandrill_response', $response );
 
 			$model->setState( NotificationState::COMPLETE );
 
-		} catch ( Mandrill_Error $e ) {
+		} catch ( \MailchimpTransactional\ApiException $e ) {
 
 			$model->setState( NotificationState::ERROR );
-			$this->error = get_class( $e ) . ' - ' . $e->getMessage();
+			$this->error = \get_class( $e ) . ' - ' . $e->getMessage();
 
 			return false;
 

--- a/lib/NotificationAdapterMandrill.php
+++ b/lib/NotificationAdapterMandrill.php
@@ -145,12 +145,12 @@ class NotificationAdapterMandrill implements NotificationAdapter {
 		if ( $response instanceof \GuzzleHttp\Exception\RequestException ) {
 			$model->setState( NotificationState::ERROR );
 			$this->error = \get_class( $response ) . ' - ' . json_decode( $response->getResponse()->getBody()->getContents() )->message;
-			return true;
+			return false;
 		} else {
 			// update post with mandrill message id.
 			update_post_meta( $model->getId(), 'rplus_mandrill_response', $response );
 			$model->setState( NotificationState::COMPLETE );
-			return false;
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/wearerequired/required-email-notifications/issues/28

~Waiting for https://github.com/mailchimp/mailchimp-client-lib-codegen/pull/245 to be merged.~ Fixed in [1.0.38](https://github.com/mailchimp/mailchimp-transactional-php/blob/master/CHANGELOG.md#1038).

**Used in** 
- Kaufleuten
- Foodwards Jobs
- Freshjobs

To test login to the development environment of Foodward Jobs or Freshjobs. If the setting send all WP Emails is enabled then you can go to the admin page for "Export Personal Data" und Tools and enter any dummy email. You should then see the email in [Mailchimp Transactional Email App](https://us3.admin.mailchimp.com/transactional/) once the test mode is enabled.

We may want to discuss renaming the class and the strings from "Mandrill" to "Mailchimp Transactional Email"